### PR TITLE
feat: add light and dark mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,8 @@ function wireCancelButtons(scope = document) {
   });
 }
 
+function applyTheme(dark){ document.body.classList.toggle('light', !dark); const meta=document.querySelector('meta[name="theme-color"]'); if(meta) meta.setAttribute('content', dark ? '#111827' : '#ffffff'); }
+
 // Hamburger menu: toggle and event delegation
 function attachMenu(){
   const btn = $('#menuBtn');
@@ -79,6 +81,7 @@ const Settings = {
     envAuto: true,
     envRollover: false,
     envHardBlock: false,
+    darkMode: true,
     quiet: true, qStart: 22, qEnd: 7
   },
   async get(){ return (await db.get('settings', this.id)) || {...this.defaults, id:this.id}; },
@@ -174,12 +177,15 @@ if ('serviceWorker' in navigator){ navigator.serviceWorker.register('./sw.js'); 
 document.addEventListener('DOMContentLoaded', async ()=>{
   attachMenu();
   wireCancelButtons();
+  const s = await Settings.get();
+  applyTheme(s.darkMode);
   await monthInit();
   await render();
 });
 
 async function render(){
   const s = await Settings.get();
+  applyTheme(s.darkMode);
   if (s.faceIdRequired){
     if (await FaceID.isSupported()){
       if (!FaceID.isUnlocked()) return renderLock();
@@ -297,6 +303,9 @@ async function renderSettings(){
     catch(e){ alert(e.message||'Failed'); }
   };
   $('#set-faceid').onchange = async ()=>{ await Settings.save({faceIdRequired: $('#set-faceid').checked}); };
+
+  $('#set-dark-mode').checked = s.darkMode;
+  $('#set-dark-mode').onchange = async ()=>{ const dark = $('#set-dark-mode').checked; applyTheme(dark); await Settings.save({darkMode: dark}); };
 
   $('#set-budget').value = s.monthlyBudget;
   $('#set-startday').value = s.startDay;

--- a/index.html
+++ b/index.html
@@ -124,6 +124,11 @@
       </div>
 
       <div class="card">
+        <h3>Appearance</h3>
+        <label class="row between"><span>Dark Mode</span><input id="set-dark-mode" type="checkbox" checked></label>
+      </div>
+
+      <div class="card">
         <h3>Budget</h3>
         <label>Monthly Budget
           <input id="set-budget" inputmode="decimal">

--- a/styles.css
+++ b/styles.css
@@ -1,35 +1,96 @@
-*{box-sizing:border-box}html,body{height:100%}body{margin:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#0b1020;color:#eef1ff}
-.appbar{position:sticky;top:0;z-index:3;display:flex;align-items:center;gap:12px;padding:12px 16px;background:#0f172a;border-bottom:1px solid #1f2a44}
-.appbar h1{font-size:18px;margin:0;flex:1}
-.icon-btn{width:36px;height:36px;border-radius:10px;border:1px solid #2d3b66;background:transparent;display:grid;place-items:center}
-.icon-btn .bars{display:block;width:18px;height:12px;position:relative}
-.icon-btn .bars::before,.icon-btn .bars::after{content:'';position:absolute;left:0;right:0;height:2px;background:#aeb8ff;border-radius:2px}
-.icon-btn .bars::before{top:0}
-.icon-btn .bars::after{bottom:0}
-.container{padding:16px;max-width:900px;margin:0 auto}
-.card{background:#111a33;border:1px solid #26335a;border-radius:14px;padding:12px;margin:12px 0}
-.row{display:flex;gap:12px;align-items:center}
-.row.wrap{flex-wrap:wrap}
-.row.between{justify-content:space-between}
-.right{text-align:right}
-.label{font-size:12px;color:#a7b1d1}
-.big{font-size:22px;font-weight:700}
-.progress{height:10px;background:#1d2644;border-radius:8px;margin-top:10px}
-.progress > div{height:10px;background:#6ea8fe;border-radius:8px;width:0%}
-.primary{background:#3b82f6;border:none;color:#fff;border-radius:10px;padding:8px 12px}
-.ghost{background:transparent;border:1px solid #2d3b66;color:#aeb8ff;border-radius:10px;padding:6px 10px}
-.list{list-style:none;padding:0;margin:0}
-.list li{border-bottom:1px solid #22305a;padding:10px 4px}
-input,select,button{font-size:16px}
-input,select{width:100%;padding:8px;border-radius:10px;border:1px solid #2d3b66;background:#0b1330;color:#eaf0ff}
-dialog{border:none;border-radius:16px;padding:16px;background:#0f152f;color:#fff;width:min(480px,92vw)}
-dialog::backdrop{background:rgba(0,0,0,.5)}
-h1,h2,h3{color:#fff}
-a{color:#93c5fd}
-pre{white-space:pre-wrap;word-break:break-word}
-.neg{color:#ff8a8a}
-/* slide-out menu */
-.menu{position:fixed;top:56px;left:8px;z-index:4;background:#0f172a;border:1px solid #1f2a44;border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,.4);padding:8px;display:grid;gap:6px;min-width:200px}
-.menu.hidden{display:none}
-.menu button{background:transparent;border:1px solid #2d3b66;color:#eaf0ff;border-radius:10px;padding:10px;text-align:left}
-.menu button:hover{background:#1d2644}
+:root {
+  color-scheme: dark;
+  --bg: #0b1020;
+  --text: #eef1ff;
+  --appbar-bg: #0f172a;
+  --appbar-border: #1f2a44;
+  --icon-border: #2d3b66;
+  --icon-bars: #aeb8ff;
+  --card-bg: #111a33;
+  --card-border: #26335a;
+  --label: #a7b1d1;
+  --progress-bg: #1d2644;
+  --progress: #6ea8fe;
+  --primary-bg: #3b82f6;
+  --ghost-border: #2d3b66;
+  --ghost-text: #aeb8ff;
+  --list-border: #22305a;
+  --input-bg: #0b1330;
+  --input-border: #2d3b66;
+  --dialog-bg: #0f152f;
+  --link: #93c5fd;
+  --neg: #ff8a8a;
+  --menu-bg: #0f172a;
+  --menu-border: #1f2a44;
+  --menu-button-border: #2d3b66;
+  --menu-button-hover: #1d2644;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+html, body { height: 100%; }
+.appbar { position: sticky; top: 0; z-index: 3; display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: var(--appbar-bg); border-bottom: 1px solid var(--appbar-border); }
+.appbar h1 { font-size: 18px; margin: 0; flex: 1; }
+.icon-btn { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--icon-border); background: transparent; display: grid; place-items: center; }
+.icon-btn .bars { display: block; width: 18px; height: 12px; position: relative; }
+.icon-btn .bars::before, .icon-btn .bars::after { content: ''; position: absolute; left: 0; right: 0; height: 2px; background: var(--icon-bars); border-radius: 2px; }
+.icon-btn .bars::before { top: 0; }
+.icon-btn .bars::after { bottom: 0; }
+.container { padding: 16px; max-width: 900px; margin: 0 auto; }
+.card { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 14px; padding: 12px; margin: 12px 0; }
+.row { display: flex; gap: 12px; align-items: center; }
+.row.wrap { flex-wrap: wrap; }
+.row.between { justify-content: space-between; }
+.right { text-align: right; }
+.label { font-size: 12px; color: var(--label); }
+.big { font-size: 22px; font-weight: 700; }
+.progress { height: 10px; background: var(--progress-bg); border-radius: 8px; margin-top: 10px; }
+.progress > div { height: 10px; background: var(--progress); border-radius: 8px; width: 0%; }
+.primary { background: var(--primary-bg); border: none; color: #fff; border-radius: 10px; padding: 8px 12px; }
+.ghost { background: transparent; border: 1px solid var(--ghost-border); color: var(--ghost-text); border-radius: 10px; padding: 6px 10px; }
+.list { list-style: none; padding: 0; margin: 0; }
+.list li { border-bottom: 1px solid var(--list-border); padding: 10px 4px; }
+input, select, button { font-size: 16px; }
+input, select { width: 100%; padding: 8px; border-radius: 10px; border: 1px solid var(--input-border); background: var(--input-bg); color: var(--text); }
+dialog { border: none; border-radius: 16px; padding: 16px; background: var(--dialog-bg); color: var(--text); width: min(480px, 92vw); }
+dialog::backdrop { background: rgba(0,0,0,.5); }
+h1, h2, h3 { color: var(--text); }
+a { color: var(--link); }
+pre { white-space: pre-wrap; word-break: break-word; }
+.neg { color: var(--neg); }
+.menu { position: fixed; top: 56px; left: 8px; z-index: 4; background: var(--menu-bg); border: 1px solid var(--menu-border); border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.4); padding: 8px; display: grid; gap: 6px; min-width: 200px; }
+.menu.hidden { display: none; }
+.menu button { background: transparent; border: 1px solid var(--menu-button-border); color: var(--text); border-radius: 10px; padding: 10px; text-align: left; }
+.menu button:hover { background: var(--menu-button-hover); }
+
+body.light {
+  color-scheme: light;
+  --bg: #f9fafb;
+  --text: #111827;
+  --appbar-bg: #ffffff;
+  --appbar-border: #e5e7eb;
+  --icon-border: #cbd5e1;
+  --icon-bars: #1f2937;
+  --card-bg: #ffffff;
+  --card-border: #e5e7eb;
+  --label: #6b7280;
+  --progress-bg: #e5e7eb;
+  --progress: #3b82f6;
+  --primary-bg: #3b82f6;
+  --ghost-border: #cbd5e1;
+  --ghost-text: #1f2937;
+  --list-border: #e5e7eb;
+  --input-bg: #ffffff;
+  --input-border: #cbd5e1;
+  --dialog-bg: #ffffff;
+  --link: #1d4ed8;
+  --neg: #dc2626;
+  --menu-bg: #ffffff;
+  --menu-border: #e5e7eb;
+  --menu-button-border: #cbd5e1;
+  --menu-button-hover: #f3f4f6;
+}


### PR DESCRIPTION
## Summary
- allow switching between light and dark themes
- store theme preference in settings and apply on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a180b944832485890fb3315c04d3