### PR TITLE
Add parseCSV tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 import { db } from './db.js';
 import { FaceID } from './faceid.js';
+import { parseCSV } from './parseCSV.js';
 
 const $ = s => document.querySelector(s);
 const $$ = s => Array.from(document.querySelectorAll(s));
@@ -364,12 +365,6 @@ async function renderImportExport(){
   };
   const h = await events();
   $('#hist-list').innerHTML = h.map(e => `<li>${histTitle(e)} <span class="label">${new Date(e.date).toLocaleString()}</span></li>`).join('');
-}
-function parseCSV(line){
-  const r=[]; let cur='', q=false; for (let i=0;i<line.length;i++){ const ch=line[i];
-    if (ch==='"'){ if (q && line[i+1]==='"'){ cur+='"'; i++; } else q = !q; }
-    else if (ch===',' && !q){ r.push(cur); cur=''; } else cur+=ch; }
-  r.push(cur); return r;
 }
 function histTitle(e){
   if (e.type==='transfer') return `Moved ${fmt(e.amount)} from ${e.fromName} to ${e.toName}`;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "budgettracker",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/parseCSV.js
+++ b/parseCSV.js
@@ -1,0 +1,12 @@
+export function parseCSV(line){
+  const r=[]; let cur='', q=false; for (let i=0;i<line.length;i++){
+    const ch=line[i];
+    if (ch==='"'){
+      if (q && line[i+1]==='"'){ cur+='"'; i++; }
+      else q = !q;
+    }
+    else if (ch===',' && !q){ r.push(cur); cur=''; }
+    else cur+=ch;
+  }
+  r.push(cur); return r;
+}

--- a/tests/parseCSV.test.js
+++ b/tests/parseCSV.test.js
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCSV } from '../parseCSV.js';
+
+test('plain fields', () => {
+  assert.deepStrictEqual(parseCSV('a,b,c'), ['a','b','c']);
+});
+
+test('quoted fields', () => {
+  assert.deepStrictEqual(parseCSV('"a","b","c"'), ['a','b','c']);
+});
+
+test('embedded commas', () => {
+  assert.deepStrictEqual(parseCSV('a,"b,c","d,e"'), ['a','b,c','d,e']);
+});
+
+test('escaped quotes', () => {
+  assert.deepStrictEqual(parseCSV('"a""b""c",d'), ['a"b"c','d']);
+});


### PR DESCRIPTION
## Summary
- expose CSV parsing logic for reuse and testing
- add node test suite covering several CSV formats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a4bb21dc8324a208ee0e997564e4