### PR TITLE
Add Pages metadata and document required files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repo is prepped for **GitHub Pages** deployment.
 
 ## Quick Deploy
 1. Create a new repo on GitHub (e.g. `budget-tracker-pwa`).  
-2. Upload **all** files from this folder to the new repo (drag & drop on GitHub works).  
-   - Make sure the `.github` folder and `.nojekyll` file are included.
+2. Upload **all** files from this folder to the new repo (drag & drop on GitHub works),
+   including the `.github/workflows` folder and the `.nojekyll` file.
 3. Go to **Settings → Pages**: set **Source** to "GitHub Actions".  
 4. Go to **Actions** tab → run the "Deploy static site to Pages" workflow.
 5. Your site will be published at: `https://<your-username>.github.io/<repo-name>/`


### PR DESCRIPTION
## Summary
- clarify README deploy instructions and mention required `.github/workflows` and `.nojekyll`
- add `.nojekyll` to disable Jekyll for GitHub Pages

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a4b456c08324a29fd3f1ed300230