### PR TITLE
Use locale-aware date formatting

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,10 +4,9 @@ import { FaceID } from './faceid.js';
 const $ = s => document.querySelector(s);
 const $$ = s => Array.from(document.querySelectorAll(s));
 const fmt = n => (new Intl.NumberFormat(undefined, {style:'currency', currency:'USD'})).format(Number(n||0));
-const pad = n => String(n).padStart(2, '0');
-const dateStr = (d) => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
-const todayStr = () => dateStr(new Date());
-const monthStart = (d=new Date()) => dateStr(new Date(d.getFullYear(), d.getMonth(), 1));
+const todayStr = () => new Date().toLocaleDateString('en-CA');
+const monthStart = (d = new Date()) =>
+  new Date(d.getFullYear(), d.getMonth(), 1).toLocaleDateString('en-CA');
 
 // Tiny toast helper
 function toast(msg){


### PR DESCRIPTION
## Summary
- replace custom YYYY-MM-DD formatter with `toLocaleDateString('en-CA')`
- compute month start via locale-aware formatting to avoid timezone offsets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896a4b19d608324a48e7e483efc05c2