### PR TITLE
Auto refresh on service worker update

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,7 +173,14 @@ window.addEventListener('beforeinstallprompt', (e) => {
   b.onclick = async ()=>{ e.prompt(); b.hidden = true; };
 });
 
-if ('serviceWorker' in navigator){ navigator.serviceWorker.register('./sw.js'); }
+if ('serviceWorker' in navigator){
+  let current = navigator.serviceWorker.controller;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (current) location.reload();
+    current = navigator.serviceWorker.controller;
+  });
+  navigator.serviceWorker.register('./sw.js');
+}
 
 // Boot
 document.addEventListener('DOMContentLoaded', async ()=>{

--- a/sw.js
+++ b/sw.js
@@ -3,9 +3,22 @@ const ASSETS = [
   './','./index.html','./styles.css','./app.js','./db.js','./faceid.js','./manifest.webmanifest',
   './icons/icon-192.png','./icons/icon-512.png'
 ];
-self.addEventListener('install', e => { e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS))); });
-self.addEventListener('activate', e => { e.waitUntil(caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))); });
+
+self.addEventListener('install', e => {
+  self.skipWaiting();
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+});
+
+self.addEventListener('activate', e => {
+  self.clients.claim();
+  e.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))
+  );
+});
+
 self.addEventListener('fetch', e => {
   const url = new URL(e.request.url);
-  if (url.origin === location.origin) e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+  if (url.origin === location.origin) {
+    e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+  }
 });


### PR DESCRIPTION
## Summary
- activate and claim service worker immediately for new builds
- reload app when service worker controller changes to ensure fresh content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896a8e8df708324845ac9d63a596003