### PR TITLE
feat: auto FaceID on iPhone

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,11 +188,14 @@ document.addEventListener('DOMContentLoaded', async ()=>{
 async function render(){
   const s = await Settings.get();
   applyTheme(s.darkMode);
-  if (s.faceIdRequired){
-    if (await FaceID.isSupported()){
-      if (!FaceID.isUnlocked()) return renderLock();
-    }
+  const isiPhone = /iPhone/i.test(navigator.userAgent);
+  if (isiPhone && await FaceID.isSupported() && !FaceID.isUnlocked()){
+    try {
+      if (!localStorage.getItem('bt_faceid_cred')) await FaceID.register();
+      await FaceID.authenticate();
+    } catch(e){ console.warn(e); }
   }
+  if (s.faceIdRequired && !FaceID.isUnlocked()) return renderLock();
   const current = (document.querySelector('#menuPanel button.active')?.dataset.tab) || 'summary';
   showTab(current, true);
 }


### PR DESCRIPTION
## Summary
- Automatically attempt Face ID on iPhone devices by checking user agent
- Only show lock screen if Face ID unlock fails and it is required

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a851d9ac8324a0296dac4b52ce26