### PR TITLE
Avoid double Face ID prompts

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,7 +132,7 @@ async function render(){
   if (isiPhone && await FaceID.isSupported() && !FaceID.isUnlocked()){
     try {
       if (!localStorage.getItem('bt_faceid_cred')) await FaceID.register();
-      await FaceID.authenticate();
+      else await FaceID.authenticate();
     } catch(e){ console.warn(e); }
   }
   if (s.faceIdRequired && !FaceID.isUnlocked()) return renderLock();
@@ -144,7 +144,11 @@ async function renderLock(){
   $('#view').innerHTML = document.querySelector('#tpl-lock').innerHTML;
   const msg = $('#lock-msg');
   $('#lock-unlock').onclick = async ()=> {
-    try { if (!localStorage.getItem('bt_faceid_cred')) await FaceID.register(); await FaceID.authenticate(); await render(); }
+    try {
+      if (!localStorage.getItem('bt_faceid_cred')) await FaceID.register();
+      else await FaceID.authenticate();
+      await render();
+    }
     catch(e){ msg.textContent = e.message || 'Failed.'; }
   };
 }

--- a/faceid.js
+++ b/faceid.js
@@ -15,6 +15,7 @@ export const FaceID = {
     if (!cred) throw new Error('Registration failed');
     const rawId = btoa(String.fromCharCode(...new Uint8Array(cred.rawId)));
     localStorage.setItem('bt_faceid_cred', rawId);
+    sessionStorage.setItem('bt_unlocked', '1');
     return true;
   },
   async authenticate(){


### PR DESCRIPTION
## Summary
- Mark user as unlocked when registering Face ID
- Only run authentication when credential exists to avoid two prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896ad0d93708324aeb4cc1e7f2e3c09