### PR TITLE
feat: prompt to reload when update available

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,12 +108,31 @@ window.addEventListener('beforeinstallprompt', (e) => {
 });
 
 if ('serviceWorker' in navigator){
+  navigator.serviceWorker.register('./sw.js').then(reg => {
+    function promptUpdate(worker){
+      if (confirm('Update available. Reload?')){
+        worker.postMessage('SKIP_WAITING');
+      }
+    }
+
+    if (reg.waiting) promptUpdate(reg.waiting);
+
+    reg.addEventListener('updatefound', () => {
+      const nw = reg.installing;
+      if (!nw) return;
+      nw.addEventListener('statechange', () => {
+        if (nw.state === 'installed' && navigator.serviceWorker.controller){
+          promptUpdate(nw);
+        }
+      });
+    });
+  });
+
   let current = navigator.serviceWorker.controller;
   navigator.serviceWorker.addEventListener('controllerchange', () => {
     if (current) location.reload();
     current = navigator.serviceWorker.controller;
   });
-  navigator.serviceWorker.register('./sw.js');
 }
 
 // Boot

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,6 @@ const ASSETS = [
 ];
 
 self.addEventListener('install', e => {
-  self.skipWaiting();
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
 
@@ -14,6 +13,10 @@ self.addEventListener('activate', e => {
   e.waitUntil(
     caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))
   );
+});
+
+self.addEventListener('message', e => {
+  if (e.data === 'SKIP_WAITING') self.skipWaiting();
 });
 
 self.addEventListener('fetch', e => {


### PR DESCRIPTION
## Summary
- prompt user to reload when a new service worker is installed
- allow service worker to skip waiting after user approves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b39039248324bec5ce7c6bf9b135