### PR TITLE
Default to light mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ const Settings = {
     lastSyncAt: null,
     monthlyBudget: 2000,
     startDay: 1,
-    darkMode: true,
+    darkMode: false,
     quiet: true, qStart: 22, qEnd: 7
   },
   async get(){ return (await db.get('settings', this.id)) || {...this.defaults, id:this.id}; },

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#111827">
+  <meta name="theme-color" content="#ffffff">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="apple-touch-icon" href="icons/icon-192.png">
   <title>Budget Tracker</title>
@@ -11,7 +11,7 @@
   <script type="module" src="app.js"></script>
   <script type="module" src="faceid.js"></script>
 </head>
-<body>
+<body class="light">
   <header class="appbar">
     <button id="menuBtn" aria-label="Menu" aria-expanded="false" aria-controls="menuPanel" class="icon-btn" title="Menu">
       <span class="bars" aria-hidden="true"></span>
@@ -121,7 +121,7 @@
 
       <div class="card">
         <h3>Appearance</h3>
-        <label class="row between"><span>Dark Mode</span><input id="set-dark-mode" type="checkbox" checked></label>
+        <label class="row between"><span>Dark Mode</span><input id="set-dark-mode" type="checkbox"></label>
       </div>
 
       <div class="card">


### PR DESCRIPTION
## Summary
- Default app theme to light mode by preloading light class and adjusting theme color
- Uncheck dark mode toggle and use light theme by default in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b3f25f9883248a2031a76640df80