### PR TITLE
Hide expense delete button until swipe

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,7 +262,14 @@ async function renderExpenses(){
     const max = 80; // width of delete button
     let startX = null;
     let curX = 0;
-    const setX = x => { curX = x; content.style.transform = `translateX(${x}px)`; };
+    const setX = x => {
+      curX = x;
+      content.style.transform = `translateX(${x}px)`;
+      const show = x !== 0;
+      del.style.opacity = show ? '1' : '0';
+      del.style.pointerEvents = show ? 'auto' : 'none';
+    };
+    setX(0);
     li.addEventListener('pointerdown', e=>{ startX = e.clientX - curX; li.setPointerCapture(e.pointerId); });
     li.addEventListener('pointermove', e=>{
       if(startX==null) return;

--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,19 @@ html, body { height: 100%; }
 .list li { border-bottom: 1px solid var(--list-border); padding: 10px 4px; touch-action: pan-y; }
 .list li.swipe-item { position: relative; overflow: hidden; }
 .list li .swipe-content { transition: transform .2s; }
-.list li .trash { position: absolute; top: 0; right: 0; bottom: 0; width: 80px; background: var(--neg); border: none; color: #fff; }
+.list li .trash {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 80px;
+  background: var(--neg);
+  border: none;
+  color: #fff;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s;
+}
 input, select, button { font-size: 16px; }
 input, select { width: 100%; padding: 8px; border-radius: 10px; border: 1px solid var(--input-border); background: var(--input-bg); color: var(--text); }
 dialog { border: none; border-radius: 16px; padding: 16px; background: var(--dialog-bg); color: var(--text); width: min(480px, 92vw); }


### PR DESCRIPTION
## Summary
- Hide expense list trash icon until the item is swiped
- Enable swipe content logic to toggle delete button visibility and pointer events
- Add CSS transitions to smoothly show/hide the delete button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b5b77a7c8324bac278e9afc803a6