### PR TITLE
Enable editing of budget and expense items

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,18 @@
     </form>
   </dialog>
 
+  <dialog id="dlg-edit-cat">
+    <form method="dialog" id="form-edit-cat">
+      <h3>Edit Category</h3>
+      <label>Name <input name="name" required></label>
+      <label>Monthly Cap <input name="cap" inputmode="decimal"></label>
+      <menu class="row between">
+        <button value="cancel">Cancel</button>
+        <button class="primary" value="ok">Save</button>
+      </menu>
+    </form>
+  </dialog>
+
   <dialog id="dlg-add-expense">
     <form method="dialog" id="form-add-expense">
       <h3>Add Expense</h3>


### PR DESCRIPTION
## Summary
- Allow clicking on expense items to edit them
- Allow clicking on budget category items to edit their name and cap
- Add category edit dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b758d2f08324b8abd424dc2eaa78