### PR TITLE
Add backup and restore capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Open the URL in Safari → **Share → Add to Home Screen**.
 
 ## Features
 - Swipe left on an expense to delete it from the list.
+- Backup all data to a JSON file and restore from a previous backup.

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import { db } from './db.js';
 import { FaceID } from './faceid.js';
 import { parseCSV } from './parseCSV.js';
+import { createBackup, loadBackup } from './backup.js';
 
 const $ = s => document.querySelector(s);
 const $$ = s => Array.from(document.querySelectorAll(s));
@@ -350,6 +351,19 @@ async function renderImportExport(){
       await addTransaction({ id: id||crypto.randomUUID(), amount:Number(amount), date, note:noteQuoted.replace(/^"|"$/g,'').replaceAll('""','"'), categoryId:catId });
     }
     alert('Imported'); render();
+  };
+
+  $('#backup-json').onclick = async ()=>{
+    const data = await createBackup();
+    const blob = new Blob([JSON.stringify(data)], {type:'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = Object.assign(document.createElement('a'), {href:url, download:'backup.json'});
+    document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  };
+  $('#restore-json').onchange = async (e)=>{
+    const file = e.target.files[0]; if (!file) return; const text = await file.text();
+    const data = JSON.parse(text); await loadBackup(data);
+    alert('Backup loaded'); render();
   };
 }
 

--- a/backup.js
+++ b/backup.js
@@ -1,0 +1,19 @@
+import { db as realDb } from './db.js';
+
+export async function createBackup(database = realDb){
+  const settings = await database.all('settings');
+  const categories = await database.all('categories');
+  const transactions = await database.all('transactions');
+  const expenses = await database.all('expenses');
+  return { settings, categories, transactions, expenses, timestamp: new Date().toISOString() };
+}
+
+export async function loadBackup(data, database = realDb){
+  if(!data) return;
+  for(const store of ['settings','categories','transactions','expenses']){
+    await database.clear(store);
+    for(const item of data[store] || []){
+      await database.put(store, item);
+    }
+  }
+}

--- a/db.js
+++ b/db.js
@@ -26,5 +26,6 @@ export const db = (() => {
   async function put(store, value) { const t = await tx([store],'readwrite'); const s = t.objectStore(store); return await new Promise((res, rej)=>{ const r = s.put(value); r.onsuccess=()=>res(value); r.onerror=()=>rej(r.error) }); }
   async function del(store, key) { const t = await tx([store],'readwrite'); const s = t.objectStore(store); return await new Promise((res, rej)=>{ const r = s.delete(key); r.onsuccess=()=>res(); r.onerror=()=>rej(r.error) }); }
   async function all(store) { const t = await tx([store]); const s = t.objectStore(store); return await new Promise((res, rej)=>{ const r = s.getAll(); r.onsuccess=()=>res(r.result||[]); r.onerror=()=>rej(r.error) }); }
-  return { get, put, del, all };
+  async function clear(store) { const t = await tx([store],'readwrite'); const s = t.objectStore(store); return await new Promise((res, rej)=>{ const r = s.clear(); r.onsuccess=()=>res(); r.onerror=()=>rej(r.error) }); }
+  return { get, put, del, all, clear };
 })();

--- a/index.html
+++ b/index.html
@@ -160,6 +160,10 @@
           <button id="export-csv" class="primary" type="button">Export Transactions CSV</button>
           <input type="file" id="import-file" accept=".csv,text/csv">
         </div>
+        <div class="card">
+          <button id="backup-json" class="primary" type="button">Backup Data</button>
+          <input type="file" id="restore-json" accept="application/json">
+        </div>
       </section>
     </template>
 

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createBackup, loadBackup } from '../backup.js';
+
+function makeMockDb(initial){
+  const stores = JSON.parse(JSON.stringify(initial));
+  return {
+    async all(store){ return [...(stores[store] || [])]; },
+    async put(store, value){
+      const arr = stores[store] || (stores[store] = []);
+      const idx = arr.findIndex(x => x.id === value.id);
+      if (idx >= 0) arr[idx] = value; else arr.push(value);
+    },
+    async clear(store){ stores[store] = []; },
+    _stores: stores
+  };
+}
+
+test('backup and restore data', async () => {
+  const initial = {
+    settings: [{id:'settings', faceIdRequired:false}],
+    categories: [{id:'c1', name:'Food', cap:100}],
+    transactions: [{id:'t1', amount:5, date:'2024-01-01', note:'', categoryId:'c1'}],
+    expenses: [{id:'e1', name:'Rent', amount:500, paid:false}]
+  };
+  const db = makeMockDb(initial);
+  const backup = await createBackup(db);
+  assert.deepStrictEqual(backup.categories, initial.categories);
+
+  // Clear and restore
+  for(const store of ['settings','categories','transactions','expenses']){
+    await db.clear(store);
+  }
+  await loadBackup(backup, db);
+  assert.deepStrictEqual(await db.all('settings'), initial.settings);
+  assert.deepStrictEqual(await db.all('categories'), initial.categories);
+  assert.deepStrictEqual(await db.all('transactions'), initial.transactions);
+  assert.deepStrictEqual(await db.all('expenses'), initial.expenses);
+});


### PR DESCRIPTION
## Summary
- allow clearing IndexedDB stores and introduce utilities to export and load complete backups
- add UI to download backup JSON and restore from a chosen file
- document backup/restore feature and cover with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b8105cf48324baa9134371826f32