### PR TITLE
feat: make budget editable from summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -216,6 +216,12 @@ async function renderSummary(){
   if (warnings.length){ capBox.style.display='block'; capBox.querySelector('#cap-list').innerHTML = warnings.map(w=>`<li>${w}</li>`).join(''); }
   else capBox.style.display='none';
 
+  const budgetBox = $('#sum-budget-box');
+  if (budgetBox){
+    budgetBox.addEventListener('click', ()=>openEditBudget());
+    budgetBox.addEventListener('keydown', e=>{ if (e.key==='Enter' || e.key===' '){ e.preventDefault(); openEditBudget(); } });
+  }
+
   $('#exp-manage').addEventListener('click', ()=>showTab('expenses'));
 }
 
@@ -400,6 +406,21 @@ async function openExpenseDialog(exp){
     if (dlg.returnValue==='ok'){
       await upsertExpense({ id: exp?.id, name:f.name.value.trim(), amount:f.amount.value, paid: exp?.paid || false });
       renderExpenses(); renderSummary();
+    }
+  };
+}
+
+async function openEditBudget(){
+  const dlg = $('#dlg-edit-budget'); const f = $('#form-edit-budget'); const s = await Settings.get();
+  f.budget.value = s.monthlyBudget;
+  dlg.showModal();
+  wireCancelButtons(dlg);
+
+  dlg.onclose = async ()=>{
+    if (dlg.returnValue==='ok'){
+      await Settings.save({ monthlyBudget: Number(f.budget.value||0) });
+      renderSummary();
+      toast('Budget updated');
     }
   };
 }

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             <div class="big" id="sum-spent">$0.00</div>
           </div>
           <div style="flex:1"></div>
-          <div class="right">
+          <div class="right clickable" id="sum-budget-box" tabindex="0" role="button">
             <div class="label">Budget</div>
             <div class="big" id="sum-budget">$2,000.00</div>
           </div>
@@ -196,6 +196,17 @@
       <h3>Add Expense</h3>
       <label>Name <input name="name" required></label>
       <label>Amount <input name="amount" inputmode="decimal" required></label>
+      <menu class="row between">
+        <button value="cancel">Cancel</button>
+        <button class="primary" value="ok">Save</button>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="dlg-edit-budget">
+    <form method="dialog" id="form-edit-budget">
+      <h3>Edit Budget</h3>
+      <label>Monthly Budget <input name="budget" inputmode="decimal" required></label>
       <menu class="row between">
         <button value="cancel">Cancel</button>
         <button class="primary" value="ok">Save</button>

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,7 @@ html, body { height: 100%; }
 .right { text-align: right; }
 .label { font-size: 12px; color: var(--label); }
 .big { font-size: 22px; font-weight: 700; }
+.clickable { cursor: pointer; }
 .progress { height: 10px; background: var(--progress-bg); border-radius: 8px; margin-top: 10px; }
 .progress > div { height: 10px; background: var(--progress); border-radius: 8px; width: 0%; }
 .primary { background: var(--primary-bg); border: none; color: #fff; border-radius: 10px; padding: 8px 12px; }


### PR DESCRIPTION
## Summary
- make budget field on summary screen clickable
- add modal dialog to edit monthly budget
- style clickable area with pointer and handle editing logic in JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b8edd4c48324960e51fea2ece7dd