### PR TITLE
Allow choosing backup save location

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Open the URL in Safari → **Share → Add to Home Screen**.
 
 ## Features
 - Swipe left on an expense to delete it from the list.
-- Backup all data to a JSON file and restore from a previous backup.
+- Backup all data to a JSON file and restore from a previous backup, choosing where the file is saved.

--- a/app.js
+++ b/app.js
@@ -382,9 +382,23 @@ async function renderImportExport(){
   $('#backup-json').onclick = async ()=>{
     const data = await createBackup();
     const blob = new Blob([JSON.stringify(data)], {type:'application/json'});
-    const url = URL.createObjectURL(blob);
-    const a = Object.assign(document.createElement('a'), {href:url, download:'backup.json'});
-    document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+    if (window.showSaveFilePicker) {
+      try {
+        const handle = await window.showSaveFilePicker({
+          suggestedName: 'backup.json',
+          types: [{ description: 'JSON Files', accept: { 'application/json': ['.json'] } }]
+        });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } catch (err) {
+        /* ignore if user cancels */
+      }
+    } else {
+      const url = URL.createObjectURL(blob);
+      const a = Object.assign(document.createElement('a'), {href:url, download:'backup.json'});
+      document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+    }
   };
   $('#restore-json').onchange = async (e)=>{
     const file = e.target.files[0]; if (!file) return; const text = await file.text();


### PR DESCRIPTION
## Summary
- Enable saving backups to a user-chosen location using the browser's save file picker with fallback
- Update README to mention selectable save location for backups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896bada3f448324bdb649493f48028c