### PR TITLE
feat: show recent transactions in summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,6 +219,16 @@ async function renderSummary(){
   if (warnings.length){ capBox.style.display='block'; capBox.querySelector('#cap-list').innerHTML = warnings.map(w=>`<li>${w}</li>`).join(''); }
   else capBox.style.display='none';
 
+  const txList = $('#sum-tx-list');
+  if (txList){
+    const recent = month.slice(0,5);
+    txList.innerHTML = recent.map(t => {
+      const name = cats.find(c=>c.id===t.categoryId)?.name || 'Uncategorized';
+      return `<li class="row between"><div><b>${name}</b><br><span class="label">${t.date}</span></div><div>${fmt(t.amount)}</div></li>`;
+    }).join('') || '<li class="label">No transactions</li>';
+    $('#sum-tx-view').addEventListener('click', ()=>showTab('transactions'));
+  }
+
   const budgetBox = $('#sum-budget-box');
   if (budgetBox){
     budgetBox.addEventListener('click', ()=>openEditBudget());

--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
         </div>
         <button id="exp-manage" class="primary" type="button">Manage Expenses</button>
       </div>
+
+      <div class="card">
+        <h3>Recent Transactions</h3>
+        <ul id="sum-tx-list" class="list"></ul>
+        <button id="sum-tx-view" class="primary" type="button">View All</button>
+      </div>
     </section>
   </template>
 


### PR DESCRIPTION
## Summary
- add recent transactions card to Summary view with quick link to full list
- render latest monthly transactions in Summary for at-a-glance tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897462d33d0832491035559e769b723