### PR TITLE
Enable automatic PWA service worker updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -133,32 +133,11 @@ window.addEventListener('beforeinstallprompt', (e) => {
 });
 
 if ('serviceWorker' in navigator){
-  const updateBtn = $('#updateBtn');
-  navigator.serviceWorker.register('./sw.js', {updateViaCache:'none'}).then(reg => {
-    function showUpdate(worker){
-      if (!updateBtn) return;
-      updateBtn.hidden = false;
-      updateBtn.onclick = () => worker.postMessage('SKIP_WAITING');
-    }
-
-    if (reg.waiting) reg.waiting.postMessage('SKIP_WAITING');
-
-    reg.addEventListener('updatefound', () => {
-      const nw = reg.installing;
-      if (!nw) return;
-      nw.addEventListener('statechange', () => {
-        if (nw.state === 'installed' && navigator.serviceWorker.controller){
-          showUpdate(nw);
-        }
-      });
-    });
-  });
-
+  navigator.serviceWorker.register('./sw.js', {updateViaCache:'none'});
   let current = navigator.serviceWorker.controller;
   navigator.serviceWorker.addEventListener('controllerchange', () => {
     if (current) location.reload();
     current = navigator.serviceWorker.controller;
-    if (updateBtn) updateBtn.hidden = true;
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
       <span class="bars" aria-hidden="true"></span>
     </button>
     <h1>Budget Tracker</h1>
-    <button id="updateBtn" class="ghost" hidden type="button">Update</button>
     <button id="installBtn" class="ghost" hidden type="button">Install</button>
   </header>
 

--- a/sw.js
+++ b/sw.js
@@ -6,17 +6,14 @@ const ASSETS = [
 
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
+  self.skipWaiting();
 });
 
 self.addEventListener('activate', e => {
-  self.clients.claim();
   e.waitUntil(
     caches.keys().then(keys => Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))
   );
-});
-
-self.addEventListener('message', e => {
-  if (e.data === 'SKIP_WAITING') self.skipWaiting();
+  self.clients.claim();
 });
 
 self.addEventListener('fetch', e => {


### PR DESCRIPTION
## Summary
- reload app automatically when a new service worker takes control
- ensure service worker updates activate immediately with `skipWaiting` and `clients.claim`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974d09cb8083248f0b412269d1ba9a