### PR TITLE
Add delete option to expense and transaction editors

### DIFF
--- a/app.js
+++ b/app.js
@@ -515,6 +515,19 @@ async function openTxDialog(tx){
   f.date.value = tx?.date || todayStr();
   f.note.value = tx?.note || '';
   f.category.value = tx?.categoryId || '';
+  const delBtn = $('#tx-delete');
+  if (tx){
+    delBtn.hidden = false;
+    delBtn.onclick = async ()=>{
+      await deleteTransaction(tx.id);
+      dlg.close('cancel');
+      await render();
+      toast('Transaction deleted');
+    };
+  } else {
+    delBtn.hidden = true;
+    delBtn.onclick = null;
+  }
   dlg.showModal();
   wireCancelButtons(dlg);
   wireCurrencyInputs(dlg);
@@ -540,6 +553,20 @@ async function openExpenseDialog(exp){
   dlg.querySelector('h3').textContent = exp ? 'Edit Expense' : 'Add Expense';
   f.name.value = exp?.name || '';
   f.amount.value = exp?.amount || '';
+  const delBtn = $('#exp-delete');
+  if (exp){
+    delBtn.hidden = false;
+    delBtn.onclick = async ()=>{
+      await deleteExpense(exp.id);
+      dlg.close('cancel');
+      renderExpenses();
+      renderSummary();
+      toast('Expense deleted');
+    };
+  } else {
+    delBtn.hidden = true;
+    delBtn.onclick = null;
+  }
   dlg.showModal();
   wireCancelButtons(dlg);
   wireCurrencyInputs(dlg);

--- a/index.html
+++ b/index.html
@@ -189,8 +189,11 @@
       </label>
       <label>Note <input name="note"></label>
       <menu class="row between">
-        <button value="cancel">Cancel</button>
-        <button class="primary" value="ok">Save</button>
+        <button id="tx-delete" class="ghost" type="button">Delete</button>
+        <div>
+          <button value="cancel">Cancel</button>
+          <button class="primary" value="ok">Save</button>
+        </div>
       </menu>
     </form>
   </dialog>
@@ -213,8 +216,11 @@
       <label>Name <input name="name" required></label>
       <label>Amount <input name="amount" inputmode="decimal" required></label>
       <menu class="row between">
-        <button value="cancel">Cancel</button>
-        <button class="primary" value="ok">Save</button>
+        <button id="exp-delete" class="ghost" type="button">Delete</button>
+        <div>
+          <button value="cancel">Cancel</button>
+          <button class="primary" value="ok">Save</button>
+        </div>
       </menu>
     </form>
   </dialog>


### PR DESCRIPTION
## Summary
- Add delete buttons in transaction and expense edit dialogs
- Wire delete buttons to remove selected transaction or expense

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974f03fc4c83248e375105917bd010