### PR TITLE
Add help and about pages with update check

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,6 +191,7 @@ function showTab(name, silent){
   if (name==='expenses') renderExpenses();
   if (name==='settings') renderSettings();
   if (name==='importexport') renderImportExport();
+  if (name==='about') renderAbout();
 }
 
 // Summary
@@ -426,12 +427,6 @@ async function renderSettings(){
   $('#diag-clear').onclick = async ()=>{ await Log.clear(); alert('Logs cleared'); };
   $('#diag-logs').textContent = (await Log.all()).join('\n');
 
-  try {
-    const {version} = await fetch('./package.json').then(r=>r.json());
-    $('#about-version').textContent = version;
-  } catch(e) {
-    $('#about-version').textContent = 'n/a';
-  }
 }
 
 // Import/Export + History
@@ -484,6 +479,25 @@ async function renderImportExport(){
     const file = e.target.files[0]; if (!file) return; const text = await file.text();
     const data = JSON.parse(text); await loadBackup(data);
     alert('Backup loaded'); render();
+  };
+}
+
+async function renderAbout(){
+  let current = 'n/a';
+  try {
+    ({version: current} = await fetch('./package.json').then(r=>r.json()));
+  } catch(e){
+    /* ignore */
+  }
+  $('#about-version').textContent = current;
+  $('#about-check-update').onclick = async ()=>{
+    try {
+      const {version: remote} = await fetch('./package.json', {cache:'no-store'}).then(r=>r.json());
+      if (remote !== current) toast(`Update available: ${remote}. Reload to update.`);
+      else toast('You are using the latest version.');
+    } catch(e){
+      toast('Unable to check for updates.');
+    }
   };
 }
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,8 @@
     <button type="button" data-tab="categories" role="menuitem">Categories</button>
     <button type="button" data-tab="settings" role="menuitem">Settings</button>
     <button type="button" data-tab="importexport" role="menuitem">Import/Export</button>
+    <button type="button" data-tab="help" role="menuitem">Help</button>
+    <button type="button" data-tab="about" role="menuitem">About</button>
   </aside>
 
   <main id="view" class="container" tabindex="-1"></main>
@@ -157,10 +159,6 @@
           </details>
         </div>
 
-      <div class="card">
-        <h3>About</h3>
-        <p>Version: <span id="about-version"></span></p>
-      </div>
     </section>
   </template>
 
@@ -177,6 +175,33 @@
         </div>
       </section>
     </template>
+
+  <template id="tpl-help">
+    <section>
+      <h2>Help</h2>
+      <div class="card">
+        <p>Use the menu to switch between sections of the app.</p>
+        <ul>
+          <li><b>Summary</b>: overview of spending and budget.</li>
+          <li><b>Transactions</b>: view or add purchases.</li>
+          <li><b>Expenses</b>: manage recurring costs.</li>
+          <li><b>Categories</b>: organize where your money goes.</li>
+          <li><b>Import/Export</b>: backup or restore your data.</li>
+          <li><b>Settings</b>: adjust appearance and preferences.</li>
+        </ul>
+      </div>
+    </section>
+  </template>
+
+  <template id="tpl-about">
+    <section>
+      <h2>About</h2>
+      <div class="card">
+        <p>Version: <span id="about-version"></span></p>
+        <button id="about-check-update" class="primary" type="button">Check for Update</button>
+      </div>
+    </section>
+  </template>
 
   <dialog id="dlg-add-tx">
     <form method="dialog" id="form-add-tx">


### PR DESCRIPTION
## Summary
- add help and about pages to navigation menu
- show current version and allow checking for updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975182b1348324952e8387bc19089e