### PR TITLE
Use timestamped backup filenames

### DIFF
--- a/app.js
+++ b/app.js
@@ -461,11 +461,13 @@ async function renderImportExport(){
 
   $('#backup-json').onclick = async ()=>{
     const data = await createBackup();
+    const timestamp = data.timestamp.replace(/[:.]/g, '-');
+    const filename = `budget_backup_${timestamp}.json`;
     const blob = new Blob([JSON.stringify(data)], {type:'application/json'});
     if (window.showSaveFilePicker) {
       try {
         const handle = await window.showSaveFilePicker({
-          suggestedName: 'backup.json',
+          suggestedName: filename,
           types: [{ description: 'JSON Files', accept: { 'application/json': ['.json'] } }]
         });
         const writable = await handle.createWritable();
@@ -476,7 +478,7 @@ async function renderImportExport(){
       }
     } else {
       const url = URL.createObjectURL(blob);
-      const a = Object.assign(document.createElement('a'), {href:url, download:'backup.json'});
+      const a = Object.assign(document.createElement('a'), {href:url, download:filename});
       document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
     }
   };

--- a/tests/backup.test.js
+++ b/tests/backup.test.js
@@ -25,6 +25,8 @@ test('backup and restore data', async () => {
   };
   const db = makeMockDb(initial);
   const backup = await createBackup(db);
+  assert.ok(backup.timestamp);
+  assert.match(backup.timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   assert.deepStrictEqual(backup.categories, initial.categories);
 
   // Clear and restore


### PR DESCRIPTION
## Summary
- Name exported backups using a timestamped `budget_backup_<timestamp>.json` format
- Verify that backups include an ISO timestamp for consistent filename generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689751ee69288324b12ca69aad6b2377