### PR TITLE
feat: overhaul credit card linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Open the URL in Safari → **Share → Add to Home Screen**.
 ## Features
 - Swipe left on an expense to delete it from the list.
 - Backup all data to a JSON file and restore from a previous backup, choosing where the file is saved.
+- Link credit cards to automatically pull balances and transaction history, with support for unlinking and deduping transactions.

--- a/creditCards.js
+++ b/creditCards.js
@@ -1,0 +1,79 @@
+import { db } from './db.js';
+
+/**
+ * Link a credit card by saving basic metadata to the database.
+ * @param {{id?:string, name:string, provider?:string, balance?:number}} card
+ * @param {*} database optional database (for testing)
+ * @returns {Promise<string>} id of the stored card
+ */
+export async function linkCreditCard(card, database = db){
+  const id = card.id || crypto.randomUUID();
+  const stored = { id, name: card.name, provider: card.provider || '', balance: card.balance || 0 };
+  await database.put('creditCards', stored);
+  return id;
+}
+
+/**
+ * Fetch balance and transaction history for a linked card.
+ * The fetcher function should return a Response-like object with a JSON body
+ * containing `{ balance:number, transactions:Array }`.
+ * @param {string} cardId
+ * @param {Function} fetcher fetch-like function
+ * @param {*} database optional database
+ */
+export async function fetchCreditCardData(cardId, fetcher = fetch, database = db){
+  const res = await fetcher(`/api/creditcards/${cardId}`);
+  if (!res || !res.ok) throw new Error('Failed to fetch card data');
+  const data = await res.json();
+  const existing = await database.get('creditCards', cardId) || { id: cardId };
+  await database.put('creditCards', { ...existing, balance: data.balance });
+  if (Array.isArray(data.transactions)){
+    const current = await getCreditCardTransactions(cardId, database);
+    const seen = new Set(current.map(t => t.id));
+    for (const tx of data.transactions){
+      const txId = tx.id || crypto.randomUUID();
+      if (seen.has(txId)) continue;
+      await database.put('cardTransactions', { ...tx, id: txId, cardId });
+    }
+  }
+  return data;
+}
+
+/**
+ * Remove a linked credit card and its transactions from the database.
+ * @param {string} cardId
+ * @param {*} database optional database
+ */
+export async function unlinkCreditCard(cardId, database = db){
+  const txs = await getCreditCardTransactions(cardId, database);
+  for (const tx of txs){
+    await database.del('cardTransactions', tx.id);
+  }
+  await database.del('creditCards', cardId);
+}
+
+/**
+ * Get metadata for a single credit card.
+ * @param {string} cardId
+ * @param {*} database optional database
+ */
+export async function getCreditCard(cardId, database = db){
+  return await database.get('creditCards', cardId);
+}
+
+/**
+ * Get all transactions for a credit card.
+ * @param {string} cardId
+ * @param {*} database optional database
+ */
+export async function getCreditCardTransactions(cardId, database = db){
+  return await database.index('cardTransactions', 'byCard', cardId);
+}
+
+/**
+ * Return all linked credit cards.
+ * @param {*} database optional database
+ */
+export async function listCreditCards(database = db){
+  return await database.all('creditCards');
+}

--- a/tests/creditCards.test.js
+++ b/tests/creditCards.test.js
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { linkCreditCard, fetchCreditCardData, getCreditCardTransactions, listCreditCards, unlinkCreditCard, getCreditCard } from '../creditCards.js';
+
+function makeMockDb(initial = {}){
+  const stores = JSON.parse(JSON.stringify(initial));
+  return {
+    async all(store){ return [...(stores[store] || [])]; },
+    async get(store, id){ return (stores[store] || []).find(x => x.id === id) || null; },
+    async put(store, value){
+      const arr = stores[store] || (stores[store] = []);
+      const idx = arr.findIndex(x => x.id === value.id);
+      if (idx >= 0) arr[idx] = value; else arr.push(value);
+    },
+    async del(store, id){
+      const arr = stores[store] || (stores[store] = []);
+      const idx = arr.findIndex(x => x.id === id);
+      if (idx >= 0) arr.splice(idx, 1);
+    },
+    async index(store, indexName, value){
+      const arr = stores[store] || [];
+      if(indexName === 'byCard') return arr.filter(x => x.cardId === value);
+      return arr.filter(x => x[indexName] === value);
+    },
+    async clear(store){ stores[store] = []; },
+    _stores: stores
+  };
+}
+
+test('link and fetch credit card data', async () => {
+  const db = makeMockDb();
+  const cardId = await linkCreditCard({ name: 'Mock Card' }, db);
+  assert.ok(cardId);
+
+  const fetcher = async () => ({
+    ok: true,
+    json: async () => ({
+      balance: 123.45,
+      transactions: [
+        { id: 'tx1', amount: 10 },
+        { amount: 20 }
+      ]
+    })
+  });
+
+  const data = await fetchCreditCardData(cardId, fetcher, db);
+  assert.equal(data.balance, 123.45);
+
+  const cards = await listCreditCards(db);
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0].balance, 123.45);
+
+  const txs = await getCreditCardTransactions(cardId, db);
+  assert.equal(txs.length, 2);
+  assert.ok(txs.every(t => t.cardId === cardId));
+  assert.ok(txs[0].id);
+  assert.ok(txs[1].id);
+});
+
+test('dedupe transactions on subsequent fetch and unlink card', async () => {
+  const db = makeMockDb();
+  const cardId = await linkCreditCard({ name: 'Second Card' }, db);
+
+  const fetcher = async () => ({
+    ok: true,
+    json: async () => ({
+      balance: 50,
+      transactions: [
+        { id: 't1', amount: 5 },
+        { id: 't2', amount: 7 }
+      ]
+    })
+  });
+
+  await fetchCreditCardData(cardId, fetcher, db);
+  await fetchCreditCardData(cardId, fetcher, db);
+
+  let txs = await getCreditCardTransactions(cardId, db);
+  assert.equal(txs.length, 2);
+
+  await unlinkCreditCard(cardId, db);
+  const card = await getCreditCard(cardId, db);
+  assert.equal(card, null);
+  txs = await getCreditCardTransactions(cardId, db);
+  assert.equal(txs.length, 0);
+});


### PR DESCRIPTION
## Summary
- dedupe fetched credit card transactions and support unlinking cards
- index card transactions by card ID for faster lookups
- document credit card management and expand tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689773dd8d0c8324b30efed613a55f10