### PR TITLE
Enable editing recent transactions from summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,9 +255,13 @@ async function renderSummary(){
     const recent = month.slice(0,5);
     txList.innerHTML = recent.map(t => {
       const name = cats.find(c=>c.id===t.categoryId)?.name || 'Uncategorized';
-      return `<li class="row between"><div><b>${name}</b><br><span class="label">${t.date}</span></div><div>${fmt(t.amount)}</div></li>`;
+      return `<li class="row between clickable" data-id="${t.id}" tabindex="0"><div><b>${name}</b><br><span class="label">${t.date}</span></div><div>${fmt(t.amount)}</div></li>`;
     }).join('') || '<li class="label">No transactions</li>';
     $('#sum-tx-view').addEventListener('click', ()=>showTab('transactions'));
+    txList.querySelectorAll('li[data-id]').forEach(li=>{
+      li.addEventListener('click', ()=>openEditTx(li.dataset.id));
+      li.addEventListener('keydown', e=>{ if (e.key==='Enter' || e.key===' '){ e.preventDefault(); openEditTx(li.dataset.id); } });
+    });
   }
 
   const budgetBox = $('#sum-budget-box');


### PR DESCRIPTION
## Summary
- Make recent transactions on the Summary view clickable
- Open the existing edit dialog from summary transactions, enabling viewing, editing, and deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897774654f48324a00d7a2289616df3