### PR TITLE
Modernize dialog popup styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -122,8 +122,42 @@ button:focus-visible {
   height: 24px;
 }
 input, select, button { font-size: 16px; }
-input, select { width: 100%; padding: 8px; border-radius: 10px; border: 1px solid var(--input-border); background: var(--input-bg); color: var(--text); }
-dialog { border: none; border-radius: 16px; padding: 16px; background: var(--dialog-bg); color: var(--text); width: min(480px, 92vw); }
+input, select {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
+  color: var(--text);
+  transition: border-color .2s, box-shadow .2s;
+}
+input:focus, select:focus {
+  border-color: var(--primary-bg);
+  box-shadow: 0 0 0 2px var(--primary-bg);
+  outline: none;
+}
+dialog {
+  border: none;
+  border-radius: 16px;
+  padding: 20px;
+  background: var(--dialog-bg);
+  color: var(--text);
+  width: min(420px, 90vw);
+  box-shadow: 0 10px 30px rgba(0,0,0,.4);
+}
+dialog form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+dialog form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+dialog menu {
+  margin-top: 16px;
+}
 dialog::backdrop { background: rgba(0,0,0,.5); }
 h1, h2, h3 { color: var(--text); }
 a { color: var(--link); }

--- a/styles.css
+++ b/styles.css
@@ -129,12 +129,15 @@ input, select {
   border: 1px solid var(--input-border);
   background: var(--input-bg);
   color: var(--text);
-  transition: border-color .2s, box-shadow .2s;
+  transition: border-color .2s;
 }
 input:focus, select:focus {
   border-color: var(--primary-bg);
-  box-shadow: 0 0 0 2px var(--primary-bg);
   outline: none;
+}
+input:focus-visible, select:focus-visible {
+  outline: 2px solid var(--primary-bg);
+  outline-offset: 2px;
 }
 dialog {
   border: none;
@@ -142,7 +145,8 @@ dialog {
   padding: 20px;
   background: var(--dialog-bg);
   color: var(--text);
-  width: min(420px, 90vw);
+  width: 90vw;
+  max-width: 420px;
   box-shadow: 0 10px 30px rgba(0,0,0,.4);
 }
 dialog form {


### PR DESCRIPTION
## Summary
- Restyled inputs with smoother focus state and spacing
- Narrowed dialog popups and added shadow for a sleeker look
- Improved layout spacing within dialog forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977795222c83249e7ebcc886361d08