### PR TITLE
Modernize dialog popups and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "budgettracker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "budgettracker",
-      "version": "1.0.6"
+      "version": "1.0.7"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budgettracker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/styles.css
+++ b/styles.css
@@ -145,8 +145,9 @@ dialog {
   padding: 20px;
   background: var(--dialog-bg);
   color: var(--text);
-  width: 90vw;
+  width: 80vw;
   max-width: 420px;
+  margin: auto;
   box-shadow: 0 10px 30px rgba(0,0,0,.4);
 }
 dialog form {


### PR DESCRIPTION
## Summary
- Reduce dialog width and center popups for a more modern look
- Bump package version to 1.0.7

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977efb27688324a37eb82109e80f09