### PR TITLE
Add credit card linking and summary balances

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <button type="button" data-tab="summary" role="menuitem">Summary</button>
     <button type="button" data-tab="transactions" role="menuitem">Transactions</button>
     <button type="button" data-tab="expenses" role="menuitem">Expenses</button>
+    <button type="button" data-tab="creditcards" role="menuitem">Credit Cards</button>
     <button type="button" data-tab="categories" role="menuitem">Categories</button>
     <button type="button" data-tab="settings" role="menuitem">Settings</button>
     <button type="button" data-tab="importexport" role="menuitem">Import/Export</button>
@@ -77,6 +78,11 @@
         <button id="exp-manage" class="primary" type="button">Manage Expenses</button>
       </div>
 
+      <div class="card" id="sum-cc-box" style="display:none">
+        <h3>Credit Cards</h3>
+        <ul id="sum-cc-list" class="list"></ul>
+      </div>
+
       <div class="card">
         <h3>Recent Transactions</h3>
         <ul id="sum-tx-list" class="list"></ul>
@@ -114,6 +120,26 @@
         <button id="expense-add" class="primary" type="button">Add</button>
       </div>
       <ul id="expense-list" class="list"></ul>
+    </section>
+  </template>
+
+  <template id="tpl-creditcards">
+    <section>
+      <div class="row">
+        <h2>Credit Cards</h2>
+        <button id="card-add" class="primary" type="button">Link</button>
+      </div>
+      <ul id="card-list" class="list"></ul>
+    </section>
+  </template>
+
+  <template id="tpl-cardtx">
+    <section>
+      <div class="row">
+        <h2 id="cardtx-name"></h2>
+        <button id="cardtx-back" class="ghost" type="button">Back</button>
+      </div>
+      <ul id="cardtx-list" class="list"></ul>
     </section>
   </template>
 
@@ -246,6 +272,19 @@
           <button value="cancel">Cancel</button>
           <button class="primary" value="ok">Save</button>
         </div>
+      </menu>
+    </form>
+  </dialog>
+
+  <dialog id="dlg-link-card">
+    <form method="dialog" id="form-link-card">
+      <h3>Link Credit Card</h3>
+      <label>Name <input name="name" required></label>
+      <label>Provider <input name="provider"></label>
+      <label>Balance <input name="balance" inputmode="decimal"></label>
+      <menu class="row between">
+        <button value="cancel">Cancel</button>
+        <button class="primary" value="ok">Save</button>
       </menu>
     </form>
   </dialog>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "budgettracker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "budgettracker",
-      "version": "1.0.7"
+      "version": "1.0.8"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budgettracker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
## Summary
- add Credit Cards tab with linking dialog and transaction history view
- show linked credit card balances in monthly summary
- bump version to 1.0.8

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897815348ec832481548ee3549691f6