### PR TITLE
Add bank account linking interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This repo is prepped for **GitHub Pages** deployment.
 
 ## Quick Deploy
-1. Create a new repo on GitHub (e.g. `budget-tracker-pwa`).  
+1. Create a new repo on GitHub (e.g. `budget-tracker-pwa`).
 2. Upload **all** files from this folder to the new repo (drag & drop on GitHub works),
    including the `.github/workflows` folder and the `.nojekyll` file.
-3. Go to **Settings → Pages**: set **Source** to "GitHub Actions".  
+3. Go to **Settings → Pages**: set **Source** to "GitHub Actions".
 4. Go to **Actions** tab → run the "Deploy static site to Pages" workflow.
 5. Your site will be published at: `https://<your-username>.github.io/<repo-name>/`
 
@@ -17,3 +17,4 @@ Open the URL in Safari → **Share → Add to Home Screen**.
 - Swipe left on an expense to delete it from the list.
 - Backup all data to a JSON file and restore from a previous backup, choosing where the file is saved.
 - Link credit cards to automatically pull balances and transaction history, with support for unlinking and deduping transactions.
+- Link bank accounts to automatically pull balances and transaction history, with support for unlinking and deduping transactions.

--- a/bankAccounts.js
+++ b/bankAccounts.js
@@ -1,0 +1,89 @@
+import { db } from './db.js';
+import { sanitizeBankApiUrl } from './bankApi.js';
+
+/**
+ * Link a bank account by saving basic metadata to the database.
+ * @param {{id?:string, name:string, institution?:string, balance?:number, bankApiUrl?:string}} account
+ * @param {*} database optional database (for testing)
+ * @returns {Promise<string>} id of the stored account
+ */
+export async function linkBankAccount(account, database = db){
+  const id = account.id || crypto.randomUUID();
+  const stored = {
+    id,
+    name: account.name,
+    institution: account.institution || '',
+    bankApiUrl: sanitizeBankApiUrl(account.bankApiUrl),
+    balance: account.balance || 0
+  };
+  await database.put('bankAccounts', stored);
+  return id;
+}
+
+/**
+ * Fetch balance and transaction history for a linked bank account.
+ * The fetcher function should return a Response-like object with a JSON body
+ * containing `{ balance:number, transactions:Array }`.
+ * @param {string} accountId
+ * @param {Function} fetcher fetch-like function
+ * @param {*} database optional database
+ */
+export async function fetchBankAccountData(accountId, fetcher = fetch, database = db){
+  const meta = await database.get('bankAccounts', accountId) || { id: accountId };
+  const endpoint = meta.bankApiUrl ? sanitizeBankApiUrl(meta.bankApiUrl) : `/api/bankaccounts/${accountId}`;
+  const res = await fetcher(endpoint);
+  if (!res || !res.ok) throw new Error('Failed to fetch account data');
+  const data = await res.json();
+  await database.put('bankAccounts', { ...meta, balance: data.balance });
+  if (Array.isArray(data.transactions)){
+    const current = await getBankAccountTransactions(accountId, database);
+    const seen = new Set(current.map(t => t.id));
+    for (const tx of data.transactions){
+      const txId = tx.id || crypto.randomUUID();
+      if (seen.has(txId)) continue;
+      await database.put('bankTransactions', { ...tx, id: txId, accountId });
+    }
+  }
+  return data;
+}
+
+/**
+ * Remove a linked bank account and its transactions from the database.
+ * @param {string} accountId
+ * @param {*} database optional database
+ */
+export async function unlinkBankAccount(accountId, database = db){
+  const txs = await getBankAccountTransactions(accountId, database);
+  for (const tx of txs){
+    await database.del('bankTransactions', tx.id);
+  }
+  await database.del('bankAccounts', accountId);
+}
+
+/**
+ * Get metadata for a single bank account.
+ * @param {string} accountId
+ * @param {*} database optional database
+ */
+export async function getBankAccount(accountId, database = db){
+  return await database.get('bankAccounts', accountId);
+}
+
+/**
+ * Get all transactions for a bank account.
+ * @param {string} accountId
+ * @param {*} database optional database
+ */
+export async function getBankAccountTransactions(accountId, database = db){
+  return await database.index('bankTransactions', 'byAccount', accountId);
+}
+
+/**
+ * Return all linked bank accounts.
+ * @param {*} database optional database
+ */
+export async function listBankAccounts(database = db){
+  const accounts = await database.all('bankAccounts');
+  return accounts.map(({ bankApiUrl, ...rest }) => rest);
+}
+

--- a/bankApi.js
+++ b/bankApi.js
@@ -1,0 +1,17 @@
+export function sanitizeBankApiUrl(url){
+  if(!url) return '';
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid bank API URL');
+  }
+  if(parsed.protocol !== 'https:'){
+    throw new Error('Bank API URL must use https');
+  }
+  parsed.username = '';
+  parsed.password = '';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString();
+}

--- a/creditCards.js
+++ b/creditCards.js
@@ -1,22 +1,5 @@
 import { db } from './db.js';
-
-function sanitizeBankApiUrl(url){
-  if(!url) return '';
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error('Invalid bank API URL');
-  }
-  if(parsed.protocol !== 'https:'){
-    throw new Error('Bank API URL must use https');
-  }
-  parsed.username = '';
-  parsed.password = '';
-  parsed.search = '';
-  parsed.hash = '';
-  return parsed.toString();
-}
+import { sanitizeBankApiUrl } from './bankApi.js';
 
 /**
  * Link a credit card by saving basic metadata to the database.

--- a/db.js
+++ b/db.js
@@ -1,7 +1,7 @@
 export const db = (() => {
   const DB_NAME = 'budget-db';
   // Bump the version whenever the database schema changes
-  const VER = 4;
+  const VER = 5;
   let _db;
   function open() {
     return new Promise((resolve, reject) => {
@@ -22,6 +22,12 @@ export const db = (() => {
         if (!d.objectStoreNames.contains('cardTransactions')) {
           const os = d.createObjectStore('cardTransactions', { keyPath: 'id' });
           os.createIndex('byCard','cardId');
+        }
+        // Stores for linked bank accounts and their transactions
+        if (!d.objectStoreNames.contains('bankAccounts')) d.createObjectStore('bankAccounts', { keyPath: 'id' });
+        if (!d.objectStoreNames.contains('bankTransactions')) {
+          const os = d.createObjectStore('bankTransactions', { keyPath: 'id' });
+          os.createIndex('byAccount','accountId');
         }
       };
       req.onsuccess = () => resolve(_db = req.result);

--- a/tests/bankAccounts.test.js
+++ b/tests/bankAccounts.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { linkBankAccount, fetchBankAccountData, getBankAccountTransactions, listBankAccounts, unlinkBankAccount, getBankAccount } from '../bankAccounts.js';
+
+function makeMockDb(initial = {}){
+  const stores = JSON.parse(JSON.stringify(initial));
+  return {
+    async all(store){ return [...(stores[store] || [])]; },
+    async get(store, id){ return (stores[store] || []).find(x => x.id === id) || null; },
+    async put(store, value){
+      const arr = stores[store] || (stores[store] = []);
+      const idx = arr.findIndex(x => x.id === value.id);
+      if (idx >= 0) arr[idx] = value; else arr.push(value);
+    },
+    async del(store, id){
+      const arr = stores[store] || (stores[store] = []);
+      const idx = arr.findIndex(x => x.id === id);
+      if (idx >= 0) arr.splice(idx, 1);
+    },
+    async index(store, indexName, value){
+      const arr = stores[store] || [];
+      if(indexName === 'byAccount') return arr.filter(x => x.accountId === value);
+      return arr.filter(x => x[indexName] === value);
+    },
+    async clear(store){ stores[store] = []; },
+    _stores: stores
+  };
+}
+
+test('link and fetch bank account data', async () => {
+  const db = makeMockDb();
+  const acctId = await linkBankAccount({ name: 'Mock Account', bankApiUrl: 'https://bank.example/api/acct' }, db);
+  assert.ok(acctId);
+
+  let calledUrl = null;
+  const fetcher = async (url) => {
+    calledUrl = url;
+    return {
+      ok: true,
+      json: async () => ({
+        balance: 500.25,
+        transactions: [
+          { id: 'tx1', amount: 100 },
+          { amount: 50 }
+        ]
+      })
+    };
+  };
+
+  const data = await fetchBankAccountData(acctId, fetcher, db);
+  assert.equal(calledUrl, 'https://bank.example/api/acct');
+  assert.equal(data.balance, 500.25);
+
+  const accounts = await listBankAccounts(db);
+  assert.equal(accounts.length, 1);
+  assert.equal(accounts[0].balance, 500.25);
+
+  const txs = await getBankAccountTransactions(acctId, db);
+  assert.equal(txs.length, 2);
+  assert.ok(txs.every(t => t.accountId === acctId));
+  assert.ok(txs[0].id);
+  assert.ok(txs[1].id);
+});
+
+test('rejects non-https bank API URL and sanitizes url', async () => {
+  const db = makeMockDb();
+  await assert.rejects(
+    () => linkBankAccount({ name: 'Bad', bankApiUrl: 'http://bank.example' }, db),
+    /https/
+  );
+  const id = await linkBankAccount({ name: 'Good', bankApiUrl: 'https://user:pass@bank.example/path?token=1#frag' }, db);
+  const acct = await getBankAccount(id, db);
+  assert.equal(acct.bankApiUrl, 'https://bank.example/path');
+});
+
+test('dedupe transactions on subsequent fetch and unlink account', async () => {
+  const db = makeMockDb();
+  const acctId = await linkBankAccount({ name: 'Second Account' }, db);
+
+  const fetcher = async () => ({
+    ok: true,
+    json: async () => ({
+      balance: 200,
+      transactions: [
+        { id: 't1', amount: 10 },
+        { id: 't2', amount: 15 }
+      ]
+    })
+  });
+
+  await fetchBankAccountData(acctId, fetcher, db);
+  await fetchBankAccountData(acctId, fetcher, db);
+
+  let txs = await getBankAccountTransactions(acctId, db);
+  assert.equal(txs.length, 2);
+
+  await unlinkBankAccount(acctId, db);
+  const acct = await getBankAccount(acctId, db);
+  assert.equal(acct, null);
+  txs = await getBankAccountTransactions(acctId, db);
+  assert.equal(txs.length, 0);
+});
+


### PR DESCRIPTION
## Summary
- implement bank account linking module with balance/transaction fetching
- persist bank accounts in IndexedDB with dedicated stores
- document bank account linking in README and add tests
- centralize HTTPS bank API URL sanitization for cards and accounts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978ebba30883248668a7bef72f7e6e