### PR TITLE
Fix credit card link popup layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -143,6 +143,7 @@ dialog {
   border: none;
   border-radius: 16px;
   padding: 20px;
+  box-sizing: border-box;
   background: var(--dialog-bg);
   color: var(--text);
   width: 80vw;


### PR DESCRIPTION
## Summary
- prevent credit card link dialog from overflowing by ensuring padding is included in width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897aefd5fe48324b68e4b34c82f9450