### PR TITLE
Clarify credit card linking in help section

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,15 @@
           <li><b>Settings</b>: adjust appearance and preferences.</li>
         </ul>
       </div>
+      <div class="card">
+        <h3>Linking Credit Card Accounts</h3>
+        <p>To pull balances and transactions automatically:</p>
+        <ol>
+          <li>Open the <b>Credit Cards</b> tab.</li>
+          <li>Press <b>Link</b> and enter your bank's API URL for the card.</li>
+          <li>Save to sync the latest credit card information.</li>
+        </ol>
+      </div>
     </section>
   </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "budgettracker",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "budgettracker",
-      "version": "1.0.10"
+      "version": "1.0.11"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budgettracker",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
## Summary
- Clarify that linking a credit card requires entering the bank's API URL
- Bump version to 1.0.11

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897af3d8d8083248192cca34cbff534