### PR TITLE
Add bank API lookup utility

### DIFF
--- a/bankApi.js
+++ b/bankApi.js
@@ -15,3 +15,34 @@ export function sanitizeBankApiUrl(url){
   parsed.hash = '';
   return parsed.toString();
 }
+
+/**
+ * Attempt to discover a bank's API endpoint using its domain name. The bank
+ * should expose a well-known JSON file at `/.well-known/bank-api` containing
+ * an `api` property with the base URL. Returns the sanitized API URL or `null`
+ * if it cannot be determined.
+ *
+ * @param {string} domain Bank domain (e.g. `example.com`)
+ * @param {Function} fetcher Optional fetch-like function
+ * @returns {Promise<string|null>} Bank API URL or null
+ */
+export async function lookupBankApi(domain, fetcher = fetch){
+  if(!domain) return null;
+  const host = domain.replace(/^https?:\/\//, '');
+  let wellKnown;
+  try {
+    wellKnown = new URL(`https://${host}/.well-known/bank-api`);
+  } catch {
+    throw new Error('Invalid bank domain');
+  }
+  const res = await fetcher(wellKnown.toString());
+  if(!res || !res.ok) return null;
+  let data;
+  try {
+    data = await res.json();
+  } catch {
+    return null;
+  }
+  if(!data || typeof data.api !== 'string') return null;
+  return sanitizeBankApiUrl(data.api);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "budgettracker",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "scripts": {
     "test": "node --test"

--- a/tests/bankApi.test.js
+++ b/tests/bankApi.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { lookupBankApi } from '../bankApi.js';
+
+const goodFetcher = async () => ({
+  ok: true,
+  json: async () => ({ api: 'https://api.example.com/path?foo=1#bar' })
+});
+
+const badFetcher = async () => ({ ok: false });
+
+const invalidJsonFetcher = async () => ({
+  ok: true,
+  json: async () => { throw new Error('no json'); }
+});
+
+test('lookupBankApi returns sanitized url when well-known file present', async () => {
+  const url = await lookupBankApi('example.com', goodFetcher);
+  assert.strictEqual(url, 'https://api.example.com/path');
+});
+
+test('lookupBankApi returns null when request fails', async () => {
+  const url = await lookupBankApi('example.com', badFetcher);
+  assert.strictEqual(url, null);
+});
+
+test('lookupBankApi returns null on invalid json', async () => {
+  const url = await lookupBankApi('example.com', invalidJsonFetcher);
+  assert.strictEqual(url, null);
+});
+
+test('lookupBankApi throws on invalid domain', async () => {
+  await assert.rejects(() => lookupBankApi('::::', goodFetcher));
+});


### PR DESCRIPTION
## Summary
- add `lookupBankApi` to discover bank API endpoints from a bank's domain using a `.well-known/bank-api` descriptor
- cover bank API lookup scenarios with tests
- bump version to 1.0.12

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b28cccc88324b28b5d8674044f15