### PR TITLE
Fix input overflow in credit card linking dialog

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,7 @@ input, select, button { font-size: 16px; }
 input, select {
   width: 100%;
   padding: 10px 14px;
+  box-sizing: border-box;
   border-radius: 12px;
   border: 1px solid var(--input-border);
   background: var(--input-bg);


### PR DESCRIPTION
## Summary
- ensure inputs fit within dialogs by using border-box sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897cc2ab32c8324b44d98515f94de1e